### PR TITLE
Increase SDK range to facilitate version transitions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,6 @@ authors:
   - Adaptant Labs <labs@adaptant.io>
 homepage: https://github.com/adaptant-labs/lipsum-dart
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=1.24.3 <3.0.0'
 dev_dependencies:
   test: any


### PR DESCRIPTION
Currently, there is no way to transition a package depending on `lorem` to dart 2 without breaking dart 1 compatibility. `lipsum` is technically compatible with dart 1 and could provide this transition path, but needs an increased SDK range in order to do so. All tests pass under dart 1.