### PR TITLE
Migrate to null safety.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,4 +8,4 @@ homepage: https://github.com/adaptant-labs/lipsum-dart
 environment:
   sdk: '>=1.24.3 <3.0.0'
 dev_dependencies:
-  test: any
+  test: ^1.20.1


### PR DESCRIPTION
Fixes adaptant-labs/lipsum-dart#4.